### PR TITLE
compatible with Swoole\Http\Response::status($http_code, $reason = null)

### DIFF
--- a/src/namespace/Http/Response.php
+++ b/src/namespace/Http/Response.php
@@ -43,9 +43,10 @@ class Response
 
     /**
      * @param $http_code[required]
+     * @param $reason
      * @return mixed
      */
-    public function status($http_code){}
+    public function status($http_code, $reason = NULL){}
 
     /**
      * @param $compress_level[optional]

--- a/src/namespace/Http/Response.php
+++ b/src/namespace/Http/Response.php
@@ -46,7 +46,7 @@ class Response
      * @param $reason
      * @return mixed
      */
-    public function status($http_code, $reason = NULL){}
+    public function status($http_code, $reason = null){}
 
     /**
      * @param $compress_level[optional]


### PR DESCRIPTION
fix warning about compatible with Swoole\Http\Response::status($http_code, $reason = NULL)